### PR TITLE
fix(client): sort search results newest-first

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -189,7 +189,7 @@ impl<M: Send + Sync> ProtonClient<M> {
         info!("Fetching {} most recent messages", recent_uids.len());
 
         let mut emails = Self::fetch_by_uids(&mut session, recent_uids).await?;
-        emails.sort_by(|a, b| b.date.cmp(&a.date));
+        emails.sort_by_key(|e| std::cmp::Reverse(e.date));
 
         session.logout().await.ok();
         Ok(emails)
@@ -212,9 +212,7 @@ impl<M: Send + Sync> ProtonClient<M> {
         let before_str = before.format("%-d-%b-%Y").to_string();
         let query = format!("SINCE {since_str} BEFORE {before_str}");
 
-        let mut emails = self.search(folder, &query).await?;
-        emails.sort_by(|a, b| b.date.cmp(&a.date));
-        Ok(emails)
+        self.search(folder, &query).await
     }
 
     /// Search emails using an arbitrary IMAP search query.
@@ -239,7 +237,8 @@ impl<M: Send + Sync> ProtonClient<M> {
 
         info!("Found {} messages matching '{}'", uid_list.len(), query);
 
-        let emails = Self::fetch_by_uids(&mut session, &uid_list).await?;
+        let mut emails = Self::fetch_by_uids(&mut session, &uid_list).await?;
+        emails.sort_by_key(|e| std::cmp::Reverse(e.date));
 
         session.logout().await.ok();
         Ok(emails)


### PR DESCRIPTION
  `ProtonClient::search` returned messages in the arbitrary order produced by `uid_search` + `fetch_by_uids`, so any caller that didn't sort explicitly got emails out of order. This broke newest-first display in `fetch_unseen`.

- Sort inside `search` itself so all downstream callers inherit newest-first ordering.
- Remove the now-redundant explicit sort in `fetch_date_range`.
- Replace `sort_by(|a, b| b.date.cmp(&a.date))` with `sort_by_key(|e| Reverse(e.date))` to satisfy `clippy::unnecessary_sort_by` under the project's pedantic lint set.

No public API change. All existing tests pass.